### PR TITLE
fix: Handle admin permissions for VIP users without admin flags

### DIFF
--- a/addons/sourcemod/scripting/VIP_SourcemodFlags.sp
+++ b/addons/sourcemod/scripting/VIP_SourcemodFlags.sp
@@ -160,7 +160,7 @@ public Action OnClientPreAdminCheck(int client)
 		else
 			g_bClientLoaded[client] = true; // Non-VIP clients should be marked as processed so they are not blocked
 
-		NotifyPostAdminCheck(client);
+		TryNotifyPostAdminCheck(client);
 		return Plugin_Handled;
 	}
 
@@ -209,7 +209,7 @@ stock void UnloadVIPClient(int client)
 		return;
 
 	RemoveClient(client);
-	
+
 	// Reset client loaded flag to allow reprocessing if VIP status is regained
 	g_bClientLoaded[client] = false;
 	g_bVIPImmunityApplied[client] = false;
@@ -308,8 +308,12 @@ stock void TryNotifyPostAdminCheck(int client)
 	{
 		RunAdminCacheChecks(client);
 
+	#if defined _sourcebanspp_included
 		if (g_bSbppClientsLoaded && g_bClientLoaded[client])
+		{
 			NotifyPostAdminCheck(client);
+		}
+	#endif
 	}
 }
 

--- a/addons/sourcemod/scripting/VIP_SourcemodFlags.sp
+++ b/addons/sourcemod/scripting/VIP_SourcemodFlags.sp
@@ -161,7 +161,7 @@ public Action OnClientPreAdminCheck(int client)
 			g_bClientLoaded[client] = true; // Non-VIP clients should be marked as processed so they are not blocked
 
 		TryNotifyPostAdminCheck(client);
-		return Plugin_Handled;
+		return Plugin_Continue;
 	}
 
 	return Plugin_Continue;
@@ -276,8 +276,9 @@ stock void LoadVIPClient(int client)
 		int currentImmunity = GetAdminImmunityLevel(curAdm);
 		int vipImmunity = g_cvVIPGroupImmunity.IntValue;
 
-		// Store original immunity level before applying VIP immunity
-		g_iOriginalImmunity[client] = currentImmunity;
+		// Store original immunity level only if VIP immunity was not previously applied
+		if (!g_bVIPImmunityApplied[client])
+			g_iOriginalImmunity[client] = currentImmunity;
 
 		// Only set VIP immunity if it's higher than current immunity
 		if (vipImmunity > currentImmunity)


### PR DESCRIPTION
## Changes Overview
This PR simplifies and improves the VIP Sourcemod Flags plugin by removing unnecessary complexity and adding proper late load support.

### Key Improvements
1. **Simplified Group Management**
   - Removed complex group handling system
   - Direct flag management instead of group inheritance
   - More straightforward immunity level handling

2. **Late Load Support**
   - Added `AskPluginLoad2` to properly detect late plugin loading
   - Added `g_bLateLoaded` flag to track plugin load state
   - Proper handling of existing clients when plugin loads late

3. **SourceBans++ Integration**
   - Simplified synchronization with SourceBans++
   - Removed unnecessary admin reload commands
   - Better handling of admin cache rebuilding

4. **Code Structure**
   - Removed unnecessary ArrayList usage
   - Simplified client loading/unloading logic
   - More efficient flag management

### Technical Details
- Removed `sm_vip_group_name` ConVar as it's no longer needed
- Simplified flag application process
- Added proper late load detection
- Improved client state management

## Repro
- Create user on sbpp
- Dont give him servers flags
- Set him web group with no flags
- Let him connect with his VIP already stored in DB
- Issue triggered

### Testing
The changes have been tested with:
- Late plugin loading
- SourceBans++ integration
- CCC integration
- VIP flag changes
- Admin cache rebuilding

### Related Issues
- Fixes issue with VIP flags not being properly applied
- Resolves late load problems
- Improves overall plugin reliability